### PR TITLE
use dev caret for ptype object in the model fit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,9 +41,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes: 
-    juliasilge/modelops,
-    rstudio/pins,
-    topepo/caret/tree/master/pkg/caret
+    juliasilge/modelops
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ VignetteBuilder:
 Remotes: 
     juliasilge/modelops,
     rstudio/pins,
-    topepo/caret/pkg/caret
+    topepo/caret/pkg
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ VignetteBuilder:
 Remotes: 
     juliasilge/modelops,
     rstudio/pins,
-    topepo/caret/pkg
+    topepo/caret/tree/master/pkg/caret
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,9 +23,9 @@ Imports:
     butcher,
     ellipsis,
     glue,
-    modelops,
-    pins (>= 0.99.9000),
-    plumber,
+    vetiver,
+    pins (>= 1.0.0),
+    plumber (>= 1.0.0),
     readr,
     rlang,
     tune
@@ -41,7 +41,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes: 
-    juliasilge/modelops
+    tidymodels/vetiver
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     rlang,
     tune
 Suggests: 
-    caret,
+    caret (>= 6.0-90),
     knitr,
     modeldata,
     ranger,
@@ -42,7 +42,8 @@ VignetteBuilder:
     knitr
 Remotes: 
     juliasilge/modelops,
-    rstudio/pins
+    rstudio/pins,
+    topepo/caret/pkg/caret
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: false

--- a/R/modelops.R
+++ b/R/modelops.R
@@ -4,14 +4,11 @@
 #' and deploy a trained model.
 #'
 #' @param model A trained model created with [caret::train()].
-#' @param data A data frame of _predictor_ columns in the same format that was
-#' given to the modeling function.
 #' @inheritParams modelops::modelops
 #' @export
 modelops.train <- function(model,
                            model_name,
                            board,
-                           data,
                            ...,
                            desc = NULL,
                            metadata = list(),
@@ -20,7 +17,7 @@ modelops.train <- function(model,
 
 
     model <- butcher::butcher(model)
-    ptype <- modelops::modelops_create_ptype(model, ptype, data)
+    ptype <- modelops::modelops_create_ptype(model, ptype)
     required_pkgs <- c("caret", model$modelInfo$library)
 
     if (rlang::is_null(desc)) {
@@ -32,8 +29,7 @@ modelops.train <- function(model,
         model_name = model_name,
         board = board,
         desc = as.character(desc),
-        metadata = modelops::modelops_meta(metadata,
-                                           required_pkgs = required_pkgs),
+        metadata = modelops::modelops_meta(metadata, required_pkgs = required_pkgs),
         ptype = ptype,
         versioned = versioned
     )
@@ -41,7 +37,7 @@ modelops.train <- function(model,
 
 
 #' @export
-modelops_slice_zero.train <- function(model, data, ...) {
-    data[0,,drop = FALSE]
+modelops_slice_zero.train <- function(model, ...) {
+    model$ptype
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,7 +70,7 @@ library(deploycaret)
 library(pins)
 
 model_board <- board_temp()
-m <- modelops(rf_fit, "sacramento_rf_caret", model_board, data = predictors)
+m <- modelops(rf_fit, "sacramento_rf_caret", model_board)
 modelops_pin_write(m)
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ library(deploycaret)
 library(pins)
 
 model_board <- board_temp()
-m <- modelops(rf_fit, "sacramento_rf_caret", model_board, data = predictors)
+m <- modelops(rf_fit, "sacramento_rf_caret", model_board)
 modelops_pin_write(m)
-#> Creating new version '20211001T015648Z-aae94'
+#> Creating new version '20211001T162030Z-a14e0'
 #> Writing to pin 'sacramento_rf_caret'
 ```
 

--- a/man/modelops.train.Rd
+++ b/man/modelops.train.Rd
@@ -8,7 +8,6 @@
   model,
   model_name,
   board,
-  data,
   ...,
   desc = NULL,
   metadata = list(),
@@ -24,9 +23,6 @@
 \item{board}{A pin board to store and version the \code{model}, created by
 \code{\link[pins:board_folder]{pins::board_folder()}}, \code{\link[pins:board_rsconnect]{pins::board_rsconnect()}}, or other \code{board_}
 function from the pins package.}
-
-\item{data}{A data frame of \emph{predictor} columns in the same format that was
-given to the modeling function.}
 
 \item{...}{Other method-specific arguments passed to \code{\link[modelops:modelops_create_ptype]{modelops_slice_zero()}}
 to compute an input data prototype.}

--- a/tests/testthat/test-modelops-pin-write.R
+++ b/tests/testthat/test-modelops-pin-write.R
@@ -6,7 +6,7 @@ lm_fit <- train(mpg ~ ., data = mtcars, method = "lm", trControl = trainControl(
 
 test_that("can pin a model", {
     b <- board_temp()
-    m <- modelops(lm_fit, "mtcars_lm", b, data = mtcars[, -1])
+    m <- modelops(lm_fit, "mtcars_lm", b)
     modelops_pin_write(m)
     # expect_equal(
     #     pin_read(b, "mtcars_lm"),
@@ -19,7 +19,7 @@ test_that("can pin a model", {
 
 test_that("default metadata for model", {
     b <- board_temp()
-    m <- modelops(lm_fit, "mtcars_lm", b, data = mtcars[, -1])
+    m <- modelops(lm_fit, "mtcars_lm", b)
     modelops_pin_write(m)
     meta <- pin_meta(b, "mtcars_lm")
     expect_equal(meta$user, list())
@@ -28,8 +28,8 @@ test_that("default metadata for model", {
 
 test_that("user can supply metadata for model", {
     b <- board_temp()
-    m <- modelops(lm_fit, "mtcars_lm", b, data = mtcars[, -1])
-    m <- modelops(lm_fit, "mtcars_lm", b, data = mtcars[, -1],
+    m <- modelops(lm_fit, "mtcars_lm", b)
+    m <- modelops(lm_fit, "mtcars_lm", b,
                   desc = "Linear regression for mtcars",
                   metadata = list(metrics = 1:10))
     modelops_pin_write(m)
@@ -41,7 +41,7 @@ test_that("user can supply metadata for model", {
 test_that("can read a pinned model", {
     skip("different environments")
     b <- board_temp()
-    m <- modelops(lm_fit, "mtcars_lm", b, data = mtcars[, -1])
+    m <- modelops(lm_fit, "mtcars_lm", b)
     modelops_pin_write(m)
     m1 <- modelops_pin_read(b, "mtcars_lm")
     meta <- pin_meta(b, "mtcars_lm")

--- a/tests/testthat/test-modelops-pr-predict.R
+++ b/tests/testthat/test-modelops-pr-predict.R
@@ -8,7 +8,7 @@ lm_fit <- train(mpg ~ ., data = mtcars, method = "lm", trControl = trainControl(
 test_that("default endpoint", {
   b <- board_temp()
 
-  m <- modelops(lm_fit, "mtcars_lm", b, data = mtcars[, -1])
+  m <- modelops(lm_fit, "mtcars_lm", b)
   modelops_pin_write(m)
 
   p <- pr() %>% modelops_pr_predict(m)


### PR DESCRIPTION
I just added a `object$ptype` in topepo/caret#1257 to eliminate the need for a `data` argument. 